### PR TITLE
Properly support null geometries

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@
  * });
  */
 function coordEach(layer, callback, excludeWrapCoord) {
+  if (!layer) return;
+
   var i, j, k, g, l, geometry, stopG, coords,
     geometryMaybeCollection,
     wrapShrink = 0,
@@ -37,6 +39,7 @@ function coordEach(layer, callback, excludeWrapCoord) {
 
     geometryMaybeCollection = (isFeatureCollection ? layer.features[i].geometry :
         (isFeature ? layer.geometry : layer));
+    if (!geometryMaybeCollection) continue;
     isGeometryCollection = geometryMaybeCollection.type === 'GeometryCollection';
     stopG = isGeometryCollection ? geometryMaybeCollection.geometries.length : 1;
 
@@ -44,6 +47,7 @@ function coordEach(layer, callback, excludeWrapCoord) {
 
       geometry = isGeometryCollection ?
           geometryMaybeCollection.geometries[g] : geometryMaybeCollection;
+      if (!geometry) continue;
       coords = geometry.coordinates;
 
       wrapShrink = (excludeWrapCoord &&

--- a/test.js
+++ b/test.js
@@ -2,6 +2,8 @@ var test = require('tape'),
     fs = require('fs'),
     meta = require('./');
 
+var nullGeometry = null;
+
 var pointGeometry = {
     type: 'Point',
     coordinates: [0, 0]
@@ -129,6 +131,17 @@ featureAndCollection(geometryCollection).forEach(function(input) {
             output.push(coord);
         });
         t.deepEqual(output, [[0, 0], [0, 0], [1, 1]]);
+        t.end();
+    });
+});
+
+featureAndCollection(nullGeometry).forEach(function(input) {
+    test('coordEach#null', function(t) {
+        var output = [];
+        meta.coordEach(input, function(coord) {
+            output.push(coord);
+        });
+        t.deepEqual(output, []);
         t.end();
     });
 });


### PR DESCRIPTION
Allowed by GeoJSON spec:
http://geojson.org/geojson-spec.html#feature-objects

Without this patch, calling turf-extent on a FeatureCollection that has a feature with a null geometry will throw an error: `Uncaught TypeError: Cannot read property 'type' of null`
